### PR TITLE
Fix UI padding issues in tabs

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/features/FeaturesRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/features/FeaturesRootSection.kt
@@ -685,23 +685,14 @@ class FeaturesRootSection : Routes.Route() {
     private fun PropertiesView(
         properties: List<PropertyPair<*>>
     ) {
-        Scaffold(
+        LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            content = { innerPadding ->
-                LazyColumn(
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .padding(innerPadding),
-                    //save button space
-                    contentPadding = PaddingValues(top = 10.dp, bottom = 110.dp),
-                    verticalArrangement = Arrangement.Top
-                ) {
-                    items(properties, key = { it.key.propertyName() }) {
-                        PropertyCard(it)
-                    }
-                }
+            verticalArrangement = Arrangement.Top
+        ) {
+            items(properties, key = { it.key.propertyName() }) {
+                PropertyCard(it)
             }
-        )
+        }
     }
 
     override val floatingActionButton: @Composable () -> Unit = {

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/scripting/ScriptingRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/scripting/ScriptingRootSection.kt
@@ -484,6 +484,7 @@ class ScriptingRootSection : Routes.Route() {
                     Box(modifier = Modifier.fillMaxSize()) {
                         LazyColumn(
                             modifier = Modifier.fillMaxSize().pullRefresh(pullRefreshState),
+                            contentPadding = PaddingValues(bottom = 120.dp),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
                             item {
@@ -544,7 +545,6 @@ class ScriptingRootSection : Routes.Route() {
                             items(scriptModules.size, key = { scriptModules[it].hashCode() }) { index ->
                                 ModuleItem(scriptModules[index])
                             }
-                            item { Spacer(modifier = Modifier.height(200.dp)) }
                         }
                         PullRefreshIndicator(
                             refreshing = refreshing,

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/social/SocialRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/social/SocialRootSection.kt
@@ -52,7 +52,7 @@ class SocialRootSection : Routes.Route() {
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize(),
-            contentPadding = PaddingValues(top = 10.dp, bottom = 110.dp, start = 8.dp, end = 8.dp),
+            contentPadding = PaddingValues(start = 8.dp, end = 8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             //check if scope list is empty
@@ -182,13 +182,7 @@ class SocialRootSection : Routes.Route() {
         }
     }
 
-    @OptIn(ExperimentalFoundationApi::class)
-    override val content: @Composable (NavBackStackEntry) -> Unit = {
-        val titles = remember {
-            listOf(translation["friends_tab"], translation["groups_tab"])
-        }
-        val coroutineScope = rememberCoroutineScope()
-        val pagerState = rememberPagerState { titles.size }
+    override val floatingActionButton: @Composable () -> Unit = {
         var addFriendDialog by remember { mutableStateOf(null as AddFriendDialog?) }
 
         if (addFriendDialog != null) {
@@ -202,85 +196,96 @@ class SocialRootSection : Routes.Route() {
             }
         }
 
+        FloatingActionButton(
+            onClick = {
+                addFriendDialog = AddFriendDialog(
+                    context,
+                    AddFriendDialog.Actions(
+                        onFriendState = { friend, state ->
+                            if (state) {
+                                context.bridgeService?.triggerScopeSync(
+                                    SocialScope.FRIEND,
+                                    friend.userId
+                                )
+                            } else {
+                                context.database.deleteFriend(friend.userId)
+                            }
+                        },
+                        onGroupState = { group, state ->
+                            if (state) {
+                                context.bridgeService?.triggerScopeSync(
+                                    SocialScope.GROUP,
+                                    group.conversationId
+                                )
+                            } else {
+                                context.database.deleteGroup(group.conversationId)
+                            }
+                        },
+                        getFriendState = { friend -> context.database.getFriendInfo(friend.userId) != null },
+                        getGroupState = { group -> context.database.getGroupInfo(group.conversationId) != null }
+                    ),
+                    pinnedIds = (friendList.map { it.userId } + groupList.map { it.conversationId }).reversed(),
+                )
+            },
+            modifier = Modifier.padding(10.dp),
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary,
+            shape = RoundedCornerShape(16.dp),
+        ) {
+            Icon(
+                imageVector = Icons.Rounded.Add,
+                contentDescription = null
+            )
+        }
+    }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    override val content: @Composable (NavBackStackEntry) -> Unit = {
+        val titles = remember {
+            listOf(translation["friends_tab"], translation["groups_tab"])
+        }
+        val coroutineScope = rememberCoroutineScope()
+        val pagerState = rememberPagerState { titles.size }
+
         LaunchedEffect(Unit) {
             updateScopeLists()
         }
 
-        Scaffold(
-            floatingActionButton = {
-                FloatingActionButton(
-                    onClick = {
-                        addFriendDialog = AddFriendDialog(
-                            context,
-                            AddFriendDialog.Actions(
-                                onFriendState = { friend, state ->
-                                    if (state) {
-                                        context.bridgeService?.triggerScopeSync(SocialScope.FRIEND, friend.userId)
-                                    } else {
-                                        context.database.deleteFriend(friend.userId)
-                                    }
-                                },
-                                onGroupState = { group, state ->
-                                    if (state) {
-                                        context.bridgeService?.triggerScopeSync(SocialScope.GROUP, group.conversationId)
-                                    } else {
-                                        context.database.deleteGroup(group.conversationId)
-                                    }
-                                },
-                                getFriendState = { friend -> context.database.getFriendInfo(friend.userId) != null },
-                                getGroupState = { group -> context.database.getGroupInfo(group.conversationId) != null }
-                            ),
-                            pinnedIds = (friendList.map { it.userId } + groupList.map { it.conversationId }).reversed(),
-                        )
-                    },
-                    modifier = Modifier.padding(10.dp),
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary,
-                    shape = RoundedCornerShape(16.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Rounded.Add,
-                        contentDescription = null
+        Column(modifier = Modifier.fillMaxSize()) {
+            TabRow(selectedTabIndex = pagerState.currentPage, indicator = { tabPositions ->
+                TabRowDefaults.SecondaryIndicator(
+                    Modifier.pagerTabIndicatorOffset(
+                        pagerState = pagerState,
+                        tabPositions = tabPositions
+                    )
+                )
+            }) {
+                titles.forEachIndexed { index, title ->
+                    Tab(
+                        selected = pagerState.currentPage == index,
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(index)
+                            }
+                        },
+                        text = {
+                            Text(
+                                text = title,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
                     )
                 }
             }
-        ) { paddingValues ->
-            Column(modifier = Modifier.padding(paddingValues)) {
-                TabRow(selectedTabIndex = pagerState.currentPage, indicator = { tabPositions ->
-                    TabRowDefaults.SecondaryIndicator(
-                        Modifier.pagerTabIndicatorOffset(
-                            pagerState = pagerState,
-                            tabPositions = tabPositions
-                        )
-                    )
-                }) {
-                    titles.forEachIndexed { index, title ->
-                        Tab(
-                            selected = pagerState.currentPage == index,
-                            onClick = {
-                                coroutineScope.launch {
-                                    pagerState.animateScrollToPage(index)
-                                }
-                            },
-                            text = {
-                                Text(
-                                    text = title,
-                                    maxLines = 2,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                            }
-                        )
-                    }
-                }
 
-                HorizontalPager(
-                    modifier = Modifier.padding(paddingValues),
-                    state = pagerState
-                ) { page ->
-                    when (page) {
-                        0 -> ScopeList(SocialScope.FRIEND)
-                        1 -> ScopeList(SocialScope.GROUP)
-                    }
+            HorizontalPager(
+                modifier = Modifier.fillMaxSize(),
+                state = pagerState
+            ) { page ->
+                when (page) {
+                    0 -> ScopeList(SocialScope.FRIEND)
+                    1 -> ScopeList(SocialScope.GROUP)
                 }
             }
         }


### PR DESCRIPTION
This commit fixes a UI bug where unnecessary blank space was present at the top and bottom of the Features, Social, and Scripts tabs. This was caused by nested Scaffolds and incorrect padding.

- In FeaturesRootSection, removed the nested Scaffold and contentPadding from the LazyColumn.
- In SocialRootSection, removed the nested Scaffold, moved the FloatingActionButton to the route's property, and fixed padding issues.
- In ScriptingRootSection, removed a Spacer and added contentPadding to the LazyColumn to prevent the FAB from hiding content.