### PR TITLE
feat: Add 'Add' button for quick actions

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeRootSection.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Help
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Settings
@@ -47,6 +48,7 @@ import me.rhunk.snapenhance.storage.setQuickTiles
 import me.rhunk.snapenhance.ui.manager.Routes
 import me.rhunk.snapenhance.ui.manager.data.Updater
 import me.rhunk.snapenhance.ui.util.ActivityLauncherHelper
+import me.rhunk.snapenhance.ui.util.AlertDialogs
 import java.text.DateFormat
 
 class HomeRootSection : Routes.Route() {
@@ -55,6 +57,7 @@ class HomeRootSection : Routes.Route() {
     }
 
     private lateinit var activityLauncherHelper: ActivityLauncherHelper
+    private lateinit var alertDialogs: AlertDialogs
 
     private val cards by lazy {
         EnumQuickActions.entries.map {
@@ -114,6 +117,7 @@ class HomeRootSection : Routes.Route() {
 
     override val init: () -> Unit = {
         activityLauncherHelper = ActivityLauncherHelper(context.activity!!)
+        alertDialogs = AlertDialogs(context.translation)
     }
 
     override val topBarActions: @Composable (RowScope.() -> Unit) = {
@@ -323,84 +327,91 @@ class HomeRootSection : Routes.Route() {
                     ) {
                         Icon(Icons.Default.MoreVert, contentDescription = null)
                     }
-                    DropdownMenu(
-                        expanded = showQuickActionsMenu,
-                        onDismissRequest = { showQuickActionsMenu = false }
-                    ) {
-                        cards.forEach { (card, _) ->
-                            fun toggle(state: Boolean? = null) {
-                                if (state?.let { !it } ?: selectedTiles.contains(card.first)) {
-                                    selectedTiles.remove(card.first)
-                                } else {
-                                    selectedTiles.add(0, card.first)
-                                }
+                    if (showQuickActionsMenu) {
+                        QuickActionsDialog(
+                            alertDialogs = alertDialogs,
+                            quickActions = cards,
+                            selectedQuickActions = selectedTiles,
+                            onDismiss = { showQuickActionsMenu = false },
+                            onSave = {
+                                selectedTiles.clear()
+                                selectedTiles.addAll(it)
                                 context.coroutineScope.launch {
                                     context.database.setQuickTiles(selectedTiles)
                                 }
+                                showQuickActionsMenu = false
                             }
-
-                            DropdownMenuItem(onClick = { toggle() }, text = {
-                                Row(
-                                    verticalAlignment = Alignment.CenterVertically,
-                                    modifier = Modifier.padding(all = 5.dp)
-                                ) {
-                                    Checkbox(
-                                        checked = selectedTiles.contains(card.first),
-                                        onCheckedChange = {
-                                            toggle(it)
-                                        }
-                                    )
-                                    Text(text = card.first)
-                                }
-                            })
-                        }
+                        )
                     }
                 }
             }
 
-            FlowRow(
-                modifier = Modifier
-                    .padding(all = cardMargin)
-                    .fillMaxWidth(),
-                maxItemsInEachRow = 3,
-                horizontalArrangement = Arrangement.SpaceEvenly,
-            ) {
-                val tileHeight = LocalDensity.current.run {
-                    remember { (context.androidContext.resources.displayMetrics.widthPixels / 3).toDp() - cardMargin / 2 }
-                }
-
-                remember(selectedTiles.size, context.translation.loadedLocale) {
-                    selectedTiles.mapNotNull {
-                        cards.entries.find { entry -> entry.key.first == it }
-                    }
-                }.forEach { (card, action) ->
-                    ElevatedCard(
-                        modifier = Modifier
-                            .height(tileHeight)
-                            .weight(1f)
-                            .padding(all = 6.dp),
-                        onClick = { action(routes) }
+            if (selectedTiles.isEmpty()) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                        .padding(16.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Button(
+                        onClick = { showQuickActionsMenu = true },
                     ) {
-                        Column(
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = "Add Quick Action",
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(text = "Add")
+                    }
+                }
+            } else {
+                FlowRow(
+                    modifier = Modifier
+                        .padding(all = cardMargin)
+                        .fillMaxWidth(),
+                    maxItemsInEachRow = 3,
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                ) {
+                    val tileHeight = LocalDensity.current.run {
+                        remember { (context.androidContext.resources.displayMetrics.widthPixels / 3).toDp() - cardMargin / 2 }
+                    }
+
+                    remember(selectedTiles.size, context.translation.loadedLocale) {
+                        selectedTiles.mapNotNull {
+                            cards.entries.find { entry -> entry.key.first == it }
+                        }
+                    }.forEach { (card, action) ->
+                        ElevatedCard(
                             modifier = Modifier
-                                .fillMaxSize()
-                                .padding(all = 5.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.SpaceEvenly,
+                                .height(tileHeight)
+                                .weight(1f)
+                                .padding(all = 6.dp),
+                            onClick = { action(routes) }
                         ) {
-                            Icon(
-                                imageVector = card.second, contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                modifier = Modifier.size(50.dp)
-                            )
-                            Text(
-                                text = card.first,
-                                lineHeight = 16.sp,
-                                fontSize = 14.sp,
-                                fontWeight = FontWeight.Bold,
-                                textAlign = TextAlign.Center,
-                                overflow = TextOverflow.Ellipsis,
-                            )
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(all = 5.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.SpaceEvenly,
+                            ) {
+                                Icon(
+                                    imageVector = card.second, contentDescription = null,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.size(50.dp)
+                                )
+                                Text(
+                                    text = card.first,
+                                    lineHeight = 16.sp,
+                                    fontSize = 14.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    textAlign = TextAlign.Center,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/QuickActionsDialog.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/QuickActionsDialog.kt
@@ -1,0 +1,79 @@
+package me.rhunk.snapenhance.ui.manager.pages.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import me.rhunk.snapenhance.ui.util.AlertDialogs
+
+@Composable
+fun QuickActionsDialog(
+    alertDialogs: AlertDialogs,
+    quickActions: Map<Pair<String, ImageVector>, () -> Unit>,
+    selectedQuickActions: List<String>,
+    onDismiss: () -> Unit,
+    onSave: (List<String>) -> Unit
+) {
+    val selected = remember { mutableStateListOf(*selectedQuickActions.toTypedArray()) }
+
+    Dialog(onDismissRequest = onDismiss) {
+        alertDialogs.DefaultDialogCard {
+            Text(
+                text = "Edit Quick Actions",
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Column {
+                quickActions.keys.forEach { (name, _) ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Checkbox(
+                            checked = selected.contains(name),
+                            onCheckedChange = { isChecked ->
+                                if (isChecked) {
+                                    selected.add(name)
+                                } else {
+                                    selected.remove(name)
+                                }
+                            }
+                        )
+                        Text(text = name, modifier = Modifier.padding(start = 8.dp))
+                    }
+                }
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+                horizontalArrangement = Arrangement.End
+            ) {
+                Button(onClick = onDismiss) {
+                    Text("Cancel")
+                }
+                Button(
+                    onClick = { onSave(selected) },
+                    modifier = Modifier.padding(start = 8.dp)
+                ) {
+                    Text("Save")
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
When there are no quick actions added on the homescreen of snapenhance, show a "Add" button with a proper icon and place it in the centre of the page.

When the user clicks on it, it opens the same menu which currently open when you click the three dots beside the test quick actions on the homscreen.

Also make that screen as a popup dialog with appropriate buttons added to it.