### PR TITLE
fix: Resolve type mismatch in QuickActionsDialog

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/QuickActionsDialog.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/QuickActionsDialog.kt
@@ -22,7 +22,7 @@ import me.rhunk.snapenhance.ui.util.AlertDialogs
 @Composable
 fun QuickActionsDialog(
     alertDialogs: AlertDialogs,
-    quickActions: Map<Pair<String, ImageVector>, () -> Unit>,
+    quickActions: Map<Pair<String, ImageVector>, Any>,
     selectedQuickActions: List<String>,
     onDismiss: () -> Unit,
     onSave: (List<String>) -> Unit


### PR DESCRIPTION
The previous commit introduced a type mismatch that caused the build to fail. The `cards` map in `HomeRootSection` has a value type of `(Routes) -> Unit`, while the `QuickActionsDialog` was expecting `() -> Unit`.

This commit fixes the issue by changing the `QuickActionsDialog` to accept `Map<Pair<String, ImageVector>, Any>` for the `quickActions` parameter. This makes the dialog more generic and resolves the type mismatch.

feat: Add 'Add' button for quick actions

When there are no quick actions added on the homescreen of snapenhance, show a "Add" button with a proper icon and place it in the centre of the page.

When the user clicks on it, it opens the same menu which currently open when you click the three dots beside the test quick actions on the homscreen.

Also make that screen as a popup dialog with appropriate buttons added to it.