### PR TITLE
feat: Improve UI for adding quick actions

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeRootSection.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.BugReport
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.Widgets
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -355,6 +356,19 @@ class HomeRootSection : Routes.Route() {
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center
                 ) {
+                    Icon(
+                        imageVector = Icons.Outlined.Widgets,
+                        contentDescription = "Quick Actions",
+                        modifier = Modifier.size(64.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "No quick actions added yet",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
                     Button(
                         onClick = { showQuickActionsMenu = true },
                     ) {

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/QuickActionsDialog.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/QuickActionsDialog.kt
@@ -1,5 +1,6 @@
 package me.rhunk.snapenhance.ui.manager.pages.home
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -33,28 +36,46 @@ fun QuickActionsDialog(
         alertDialogs.DefaultDialogCard {
             Text(
                 text = "Edit Quick Actions",
-                style = MaterialTheme.typography.titleLarge,
-                modifier = Modifier.padding(bottom = 16.dp)
+                style = MaterialTheme.typography.headlineSmall
+            )
+            Text(
+                text = "Select the actions you want to see on the home screen.",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 8.dp, bottom = 16.dp)
             )
 
             Column {
-                quickActions.keys.forEach { (name, _) ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Checkbox(
-                            checked = selected.contains(name),
-                            onCheckedChange = { isChecked ->
-                                if (isChecked) {
-                                    selected.add(name)
-                                } else {
-                                    selected.remove(name)
-                                }
+                quickActions.keys.forEach { (name, icon) ->
+                    val isSelected = selected.contains(name)
+                    ListItem(
+                        modifier = Modifier.clickable {
+                            if (isSelected) {
+                                selected.remove(name)
+                            } else {
+                                selected.add(name)
                             }
-                        )
-                        Text(text = name, modifier = Modifier.padding(start = 8.dp))
-                    }
+                        },
+                        headlineContent = { Text(name) },
+                        leadingContent = {
+                            Icon(
+                                imageVector = icon,
+                                contentDescription = name,
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        },
+                        trailingContent = {
+                            Checkbox(
+                                checked = isSelected,
+                                onCheckedChange = { isChecked ->
+                                    if (isChecked) {
+                                        selected.add(name)
+                                    } else {
+                                        selected.remove(name)
+                                    }
+                                }
+                            )
+                        }
+                    )
                 }
             }
 
@@ -62,7 +83,8 @@ fun QuickActionsDialog(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 16.dp),
-                horizontalArrangement = Arrangement.End
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Button(onClick = onDismiss) {
                     Text("Cancel")


### PR DESCRIPTION
This commit introduces several UI/UX improvements for the quick actions feature on the home screen.

- When no quick actions are selected, a large icon and descriptive text are displayed, along with an "Add" button to make the screen more intuitive and visually appealing.
- The dropdown menu for editing quick actions has been replaced with a more user-friendly and aesthetically pleasing dialog.
- The dialog now shows icons for each quick action, uses Material Design `ListItem` components for a cleaner layout, and includes a descriptive subtitle.
- A previous build failure due to a type mismatch in the dialog's parameters has also been resolved.