### PR TITLE
feat: Improve quick actions UI and fix layout issues

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeRootSection.kt
@@ -58,7 +58,6 @@ class HomeRootSection : Routes.Route() {
     }
 
     private lateinit var activityLauncherHelper: ActivityLauncherHelper
-    private lateinit var alertDialogs: AlertDialogs
 
     private val cards by lazy {
         EnumQuickActions.entries.map {
@@ -118,7 +117,6 @@ class HomeRootSection : Routes.Route() {
 
     override val init: () -> Unit = {
         activityLauncherHelper = ActivityLauncherHelper(context.activity!!)
-        alertDialogs = AlertDialogs(context.translation)
     }
 
     override val topBarActions: @Composable (RowScope.() -> Unit) = {
@@ -330,7 +328,6 @@ class HomeRootSection : Routes.Route() {
                     }
                     if (showQuickActionsMenu) {
                         QuickActionsDialog(
-                            alertDialogs = alertDialogs,
                             quickActions = cards,
                             selectedQuickActions = selectedTiles,
                             onDismiss = { showQuickActionsMenu = false },
@@ -348,37 +345,40 @@ class HomeRootSection : Routes.Route() {
             }
 
             if (selectedTiles.isEmpty()) {
-                Column(
+                Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(200.dp)
-                        .padding(16.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
+                        .height(300.dp),
+                    contentAlignment = Alignment.Center
                 ) {
-                    Icon(
-                        imageVector = Icons.Outlined.Widgets,
-                        contentDescription = "Quick Actions",
-                        modifier = Modifier.size(64.dp),
-                        tint = MaterialTheme.colorScheme.primary
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text(
-                        text = "No quick actions added yet",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Button(
-                        onClick = { showQuickActionsMenu = true },
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
                     ) {
                         Icon(
-                            imageVector = Icons.Default.Add,
-                            contentDescription = "Add Quick Action",
-                            modifier = Modifier.size(24.dp)
+                            imageVector = Icons.Outlined.Widgets,
+                            contentDescription = "Quick Actions",
+                            modifier = Modifier.size(64.dp),
+                            tint = MaterialTheme.colorScheme.primary
                         )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = "Add")
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = "No quick actions added yet",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Button(
+                            onClick = { showQuickActionsMenu = true },
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Add,
+                                contentDescription = "Add Quick Action",
+                                modifier = Modifier.size(24.dp)
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(text = "Add")
+                        }
                     }
                 }
             } else {

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/QuickActionsDialog.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/QuickActionsDialog.kt
@@ -1,30 +1,27 @@
 package me.rhunk.snapenhance.ui.manager.pages.home
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
-import me.rhunk.snapenhance.ui.util.AlertDialogs
 
 @Composable
 fun QuickActionsDialog(
-    alertDialogs: AlertDialogs,
     quickActions: Map<Pair<String, ImageVector>, Any>,
     selectedQuickActions: List<String>,
     onDismiss: () -> Unit,
@@ -32,19 +29,23 @@ fun QuickActionsDialog(
 ) {
     val selected = remember { mutableStateListOf(*selectedQuickActions.toTypedArray()) }
 
-    Dialog(onDismissRequest = onDismiss) {
-        alertDialogs.DefaultDialogCard {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
             Text(
                 text = "Edit Quick Actions",
                 style = MaterialTheme.typography.headlineSmall
             )
-            Text(
-                text = "Select the actions you want to see on the home screen.",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.padding(top = 8.dp, bottom = 16.dp)
-            )
-
-            Column {
+        },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState())
+            ) {
+                Text(
+                    text = "Select the actions you want to see on the home screen.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
                 quickActions.keys.forEach { (name, icon) ->
                     val isSelected = selected.contains(name)
                     ListItem(
@@ -78,24 +79,20 @@ fun QuickActionsDialog(
                     )
                 }
             }
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 16.dp),
-                horizontalArrangement = Arrangement.End,
-                verticalAlignment = Alignment.CenterVertically
+        },
+        confirmButton = {
+            Button(
+                onClick = { onSave(selected) }
             ) {
-                Button(onClick = onDismiss) {
-                    Text("Cancel")
-                }
-                Button(
-                    onClick = { onSave(selected) },
-                    modifier = Modifier.padding(start = 8.dp)
-                ) {
-                    Text("Save")
-                }
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss
+            ) {
+                Text("Cancel")
             }
         }
-    }
+    )
 }


### PR DESCRIPTION
This commit addresses user feedback on the quick actions feature:

- The empty state UI on the home screen is now properly centered as a whole group (icon, text, and button).
- The 'Edit Quick Actions' dialog has been refactored to use the standard `AlertDialog` composable. This fixes a visual glitch where the dialog appeared to have two separate backgrounds, ensuring a unified and theme-consistent look.

These changes build upon the initial implementation of the 'Add' button and dialog, further improving the user experience and visual appeal of the feature.