### PR TITLE
feat: Add granular controls for AMOLED theme

### DIFF
--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/CustomTheming.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/CustomTheming.kt
@@ -37,7 +37,10 @@ class CustomTheming : Feature("Custom Theming") {
                     return@hook
                 }
 
-                if (amoledThemeConfig.properties.find { it.key.name == attrName }?.value?.get() != true) return@hook
+                val propertyKey = amoledThemeConfig.properties.keys.find { it.name == attrName }
+                if (propertyKey == null) return@hook
+                val propertyValue = amoledThemeConfig.properties[propertyKey]
+                if (propertyValue?.get() != true) return@hook
 
                 val type = result.getType(0)
                 if (type in colorTypes) {


### PR DESCRIPTION
This commit introduces a new settings screen for the 'Force AMOLED Theme' feature, allowing users to toggle individual color attributes.

- A new `AmoledThemeConfig` class was created to hold a boolean property for each theming attribute.
- `UserInterfaceTweaks` was updated to use this new config container.
- `CustomTheming` logic was modified to check the individual toggles before patching colors.
- A dedicated UI was created in `FeaturesRootSection` with a new route, a `Scaffold`, and a `FloatingActionButton` to provide a 'Save' button and a screen for the toggles.