### PR TITLE
feat(lang): add name and description for force_amoled_theme

### DIFF
--- a/common/src/main/assets/lang/en_US.json
+++ b/common/src/main/assets/lang/en_US.json
@@ -469,6 +469,10 @@
                             }
                         }
                     },
+                    "force_amoled_theme": {
+                        "name": "Amoled Dark mode",
+                        "description": "Uses a true black background for the dark theme, which can save battery on AMOLED screens."
+                    },
                     "map_friend_nametags": {
                         "name": "Enhanced Friend Map Nametags",
                         "description": "Improves the Nametags of friends on the Snapmap"


### PR DESCRIPTION
The "force amoled theme" feature was missing a name and description in the user interface.

This commit adds the name "Amoled Dark mode" and a relevant description to the feature.