### PR TITLE
fix: Attempt to fix persistent compilation errors

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/RemoteSideContext.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/RemoteSideContext.kt
@@ -154,7 +154,7 @@ class RemoteSideContext(
                 )
             },
             modInfo = ModInfo(
-                loaderPackageName = MainActivity::class.java.`package`?.name ?: "unknown",
+                loaderPackageName = MainActivity::class.java.`package`?.let { it.name } ?: "unknown",
                 buildPackageName = androidContext.packageName,
                 buildVersion = BuildConfig.VERSION_NAME,
                 buildVersionCode = BuildConfig.VERSION_CODE.toLong(),


### PR DESCRIPTION
This commit attempts to fix the persistent compilation errors that have been causing the build to fail.

- Rewrites the nullable property access in `RemoteSideContext.kt` using a `let` block to be more explicit.
- Corrects the iteration over `unique` property values in `HomeSettings.kt`.