### PR TITLE
Fix native library stripping warning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,6 +74,7 @@ android {
     packaging {
         jniLibs {
             excludes += "**/*_neon.so"
+            doNotStrip.add("**/*.so")
         }
         resources {
             excludes += "DebugProbesKt.bin"

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/spying/FriendTracker.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/spying/FriendTracker.kt
@@ -114,6 +114,7 @@ class FriendTracker : Feature("Friend Tracker") {
                     eventType.key,
                     extras
                 )
+                TrackerRuleAction.CUSTOM -> {}
             }
         }
     }


### PR DESCRIPTION
This commit fixes a build warning about being unable to strip certain native libraries. It adds a `doNotStrip` rule to the packaging options to prevent stripping of all `.so` files.