### PR TITLE
fix(native): Resolve native library packaging race condition

### DIFF
--- a/native/build.gradle.kts
+++ b/native/build.gradle.kts
@@ -41,7 +41,6 @@ kotlin {
 
 cargo {
     module = "rust"
-    libname = nativeName.toString()
     targetIncludes = arrayOf("libsnapenhance.so")
     profile = "release"
     targets = listOf("arm64", "arm")
@@ -61,6 +60,12 @@ val buildAndRename by tasks.registering {
                 file.renameTo(File(file.parent, "lib$nativeName.so"))
             }
         }
+    }
+}
+
+android.libraryVariants.all { variant ->
+    tasks.named("merge${variant.name.capitalize()}JniLibFolders").configure {
+        dependsOn(buildAndRename)
     }
 }
 


### PR DESCRIPTION
The application was crashing with a `java.lang.UnsatisfiedLinkError` because the native library (`.so` file) was not found at runtime.

This was caused by a race condition in the `native` module's build script:
1. The Rust library was compiled to `libsnapenhance.so`.
2. A custom task, `buildAndRename`, was responsible for renaming the library to a unique, hashed name (`lib<buildHash>.so`).
3. The standard Android JNI packaging tasks were not configured to wait for `buildAndRename` to complete.

As a result, the packaging tasks would often run before the library was renamed, packaging the original `libsnapenhance.so` instead of the expected `lib<buildHash>.so`. The application code, which correctly looks for the hashed name, would then fail to find the library.

This commit fixes the issue by:
- Removing the redundant and conflicting `libname` property from the `cargo` configuration.
- Adding an explicit dependency for the `mergeJniLibFolders` tasks on the `buildAndRename` task.

This ensures the library is always renamed to its final, hashed name before being packaged into the APK, resolving the race condition.