### PR TITLE
Fix updater crashes and localization issues

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/data/UpdateDownloader.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/data/UpdateDownloader.kt
@@ -30,7 +30,15 @@ object UpdateDownloader {
 
     private fun getInstance(context: Context): Fetch {
         if (fetch == null) {
-            fetch = (context.applicationContext as RemoteSideContext).fetch
+            val appContext = context.applicationContext
+            fetch = if (appContext is RemoteSideContext) {
+                appContext.fetch
+            } else {
+                val fetchConfiguration = FetchConfiguration.Builder(appContext)
+                    .setDownloadConcurrentLimit(3)
+                    .build()
+                Fetch.getInstance(fetchConfiguration)
+            }
         }
         return fetch!!
     }

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeSettings.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeSettings.kt
@@ -221,7 +221,7 @@ class HomeSettings : Routes.Route() {
             }
             Spacer(Modifier.height(20.dp))
 
-            RowTitle(title = translation["actions_title"])
+            RowTitle(title = translation["manager.sections.home_settings.actions_title"])
             EnumAction.entries.forEach { enumAction ->
                 RowAction(key = enumAction.key) {
                     context.launchActionIntent(enumAction)
@@ -247,6 +247,9 @@ class HomeSettings : Routes.Route() {
                             .clickable {
                                 autoUpdateCheck = !autoUpdateCheck
                                 context.config.root.global.updateSettings.autoUpdateCheck.set(autoUpdateCheck)
+                                if (autoUpdateCheck && context.config.root.global.updateSettings.updateCheckFrequency.getNullable() == null) {
+                                    context.config.root.global.updateSettings.updateCheckFrequency.set("weekly")
+                                }
                                 context.config.writeConfig()
                                 scheduleUpdateCheck()
                             },
@@ -257,6 +260,9 @@ class HomeSettings : Routes.Route() {
                         Switch(checked = autoUpdateCheck, onCheckedChange = {
                             autoUpdateCheck = it
                             context.config.root.global.updateSettings.autoUpdateCheck.set(it)
+                            if (it && context.config.root.global.updateSettings.updateCheckFrequency.getNullable() == null) {
+                                context.config.root.global.updateSettings.updateCheckFrequency.set("weekly")
+                            }
                             context.config.writeConfig()
                             scheduleUpdateCheck()
                         }, modifier = Modifier.padding(end = 26.dp))
@@ -266,6 +272,7 @@ class HomeSettings : Routes.Route() {
                     val frequencies = remember { listOf("daily", "weekly", "monthly") }
                     var selectedFrequency by remember { mutableStateOf(context.config.root.global.updateSettings.updateCheckFrequency.getNullable() ?: "weekly") }
 
+                    Text(text = translation["manager.sections.home_settings.update_check_frequency"], modifier = Modifier.padding(top = 8.dp, bottom = 4.dp), fontSize = 14.sp)
                     ExposedDropdownMenuBox(
                         expanded = expanded,
                         onExpandedChange = { expanded = it },
@@ -294,7 +301,7 @@ class HomeSettings : Routes.Route() {
                 }
             }
 
-            RowTitle(title = translation["message_logger_title"])
+            RowTitle(title = translation["manager.sections.home_settings.message_logger_title"])
             ShiftedRow {
                 Column(
                     verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -365,7 +372,7 @@ class HomeSettings : Routes.Route() {
                     }
                 }
             }
-            RowTitle(title = translation["debug_title"])
+            RowTitle(title = translation["manager.sections.home_settings.debug_title"])
             Row(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
This commit fixes three issues related to the updater functionality:

1.  A crash when downloading an update from the manager UI. This was caused by a `ClassCastException` when trying to cast the `Application` context to `RemoteSideContext`. The fix is to create a new `Fetch` instance when not in the `RemoteSideContext`.

2.  A crash when enabling the auto-updater. This was caused by an `IllegalStateException` when trying to access the `updateCheckFrequency` property before it was set. The fix is to set a default value for this property when auto-update is enabled.

3.  Localization keys being displayed instead of text for the auto-update settings. The fix is to use fully qualified translation keys in the UI code.