### PR TITLE
feat(ui): add haptic feedback for toggles

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/features/FeaturesRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/features/FeaturesRootSection.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -251,9 +253,13 @@ class FeaturesRootSection : Routes.Route() {
         when (val dataType = remember { property.key.dataType.type }) {
             DataProcessors.Type.BOOLEAN -> {
                 var state by remember { mutableStateOf(propertyValue.get() as Boolean) }
+                val hapticFeedback = LocalHapticFeedback.current
                 Switch(
                     checked = state,
                     onCheckedChange = registerClickCallback {
+                        if (context.config.root.global.uiSettings.hapticFeedback.get()) {
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                        }
                         state = state.not()
                         propertyValue.setAny(state)
                     }
@@ -363,9 +369,13 @@ class FeaturesRootSection : Routes.Route() {
                         ))
                 }
 
+                val hapticFeedback = LocalHapticFeedback.current
                 Switch(
                     checked = state,
                     onCheckedChange = {
+                        if (context.config.root.global.uiSettings.hapticFeedback.get()) {
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                        }
                         state = state.not()
                         container.globalState = state
                     }

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeSettings.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeSettings.kt
@@ -14,7 +14,9 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -85,11 +87,15 @@ class HomeSettings : Routes.Route() {
     private fun PreferenceToggle(sharedPreferences: SharedPreferences, key: String, text: String) {
         val realKey = "debug_$key"
         var value by remember { mutableStateOf(sharedPreferences.getBoolean(realKey, false)) }
+        val hapticFeedback = LocalHapticFeedback.current
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .heightIn(min = 55.dp)
                 .clickable {
+                    if (context.config.root.global.uiSettings.hapticFeedback.get()) {
+                        hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                    }
                     value = !value
                     sharedPreferences
                         .edit() {
@@ -101,6 +107,9 @@ class HomeSettings : Routes.Route() {
         ) {
             Text(text = text, modifier = Modifier.padding(end = 16.dp), fontSize = 14.sp)
             Switch(checked = value, onCheckedChange = {
+                if (context.config.root.global.uiSettings.hapticFeedback.get()) {
+                    hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                }
                 value = it
                 sharedPreferences.edit().putBoolean(realKey, it).apply()
             }, modifier = Modifier.padding(end = 26.dp))
@@ -236,6 +245,33 @@ class HomeSettings : Routes.Route() {
                 context.checkForRequirements(Requirements.LANGUAGE)
             }
 
+            RowTitle(title = "UI Settings")
+            ShiftedRow {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 55.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(text = "Haptic Feedback")
+                    var hapticFeedbackEnabled by remember { mutableStateOf(context.config.root.global.uiSettings.hapticFeedback.getNullable() ?: true) }
+                    val hapticFeedback = LocalHapticFeedback.current
+                    Switch(
+                        checked = hapticFeedbackEnabled,
+                        onCheckedChange = {
+                            if (it) {
+                                hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                            }
+                            hapticFeedbackEnabled = it
+                            context.config.root.global.uiSettings.hapticFeedback.set(it)
+                            context.config.writeConfig()
+                        },
+                        modifier = Modifier.padding(end = 26.dp)
+                    )
+                }
+            }
+
             RowTitle(title = translation["updates_title"])
             ShiftedRow {
                 Column(
@@ -297,9 +333,13 @@ class HomeSettings : Routes.Route() {
                                 }
                             }
 
+                            val hapticFeedback = LocalHapticFeedback.current
                             Switch(
                                 checked = autoUpdateCheck,
                                 onCheckedChange = {
+                                    if (context.config.root.global.uiSettings.hapticFeedback.get()) {
+                                         hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                                    }
                                     autoUpdateCheck = it
                                     context.config.root.global.updateSettings.autoUpdateCheck.set(it)
                                     if (it && context.config.root.global.updateSettings.updateCheckFrequency.getNullable() == null) {

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/Global.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/Global.kt
@@ -61,5 +61,13 @@ class Global : ConfigContainer() {
         val autoUpdateCheck = boolean("auto_update_check")
         val updateCheckFrequency = unique("update_check_frequency", "daily", "weekly", "monthly")
     }
+
+    inner class UISettings : ConfigContainer() {
+        val hapticFeedback = boolean("haptic_feedback") {
+            defaultValue = true
+        }
+    }
+
     val updateSettings = container("update_settings", UpdateSettings())
+    val uiSettings = container("ui_settings", UISettings())
 }


### PR DESCRIPTION
Adds haptic feedback for all toggles in the app.

A new setting is added to enable/disable this feature.

The haptic feedback is triggered when a toggle is switched on or off.

This addresses the user's request to have haptic feedback on all toggles.