### PR TITLE
feat(ui): add haptic feedback for toggles

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/features/FeaturesRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/features/FeaturesRootSection.kt
@@ -258,7 +258,7 @@ class FeaturesRootSection : Routes.Route() {
                     checked = state,
                     onCheckedChange = registerClickCallback {
                         if (context.config.root.global.uiSettings.hapticFeedback.get()) {
-                            hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                         }
                         state = state.not()
                         propertyValue.setAny(state)
@@ -374,7 +374,7 @@ class FeaturesRootSection : Routes.Route() {
                     checked = state,
                     onCheckedChange = {
                         if (context.config.root.global.uiSettings.hapticFeedback.get()) {
-                            hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                         }
                         state = state.not()
                         container.globalState = state

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeSettings.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeSettings.kt
@@ -94,7 +94,7 @@ class HomeSettings : Routes.Route() {
                 .heightIn(min = 55.dp)
                 .clickable {
                     if (context.config.root.global.uiSettings.hapticFeedback.get()) {
-                        hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                     }
                     value = !value
                     sharedPreferences
@@ -108,7 +108,7 @@ class HomeSettings : Routes.Route() {
             Text(text = text, modifier = Modifier.padding(end = 16.dp), fontSize = 14.sp)
             Switch(checked = value, onCheckedChange = {
                 if (context.config.root.global.uiSettings.hapticFeedback.get()) {
-                    hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                 }
                 value = it
                 sharedPreferences.edit().putBoolean(realKey, it).apply()
@@ -261,7 +261,7 @@ class HomeSettings : Routes.Route() {
                         checked = hapticFeedbackEnabled,
                         onCheckedChange = {
                             if (it) {
-                                hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                             }
                             hapticFeedbackEnabled = it
                             context.config.root.global.uiSettings.hapticFeedback.set(it)
@@ -338,7 +338,7 @@ class HomeSettings : Routes.Route() {
                                 checked = autoUpdateCheck,
                                 onCheckedChange = {
                                     if (context.config.root.global.uiSettings.hapticFeedback.get()) {
-                                         hapticFeedback.performHapticFeedback(HapticFeedbackType.Confirm)
+                                         hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
                                     }
                                     autoUpdateCheck = it
                                     context.config.root.global.updateSettings.autoUpdateCheck.set(it)


### PR DESCRIPTION
Adds haptic feedback for all toggles in the app.

A new setting is added to enable/disable this feature.

The haptic feedback is triggered when a toggle is switched on or off.

This addresses the user's request to have haptic feedback on all toggles.