### PR TITLE
feat: add legacy ui toggle and updated home styling

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/MainActivity.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/MainActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.background
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.*
@@ -14,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -66,8 +68,8 @@ class MainActivity : ComponentActivity() {
                 })
             }
             val startDestination = remember { intent.getStringExtra("route") ?: routes.home.routeInfo.id }
-
-            AppMaterialTheme(themeMode = themeMode) {
+            val useLegacyUi = remember { managerContext.config.root.global.uiSettings.legacyUI.get() }
+            AppMaterialTheme(themeMode = themeMode, legacyUi = useLegacyUi) {
                 val background = MaterialTheme.colorScheme.background
                 val isLight = background.luminance() > 0.5f
                 val view = LocalView.current
@@ -80,9 +82,14 @@ class MainActivity : ComponentActivity() {
                     insetsController.isAppearanceLightStatusBars = isLight
                     insetsController.isAppearanceLightNavigationBars = isLight
                 }
+                val backgroundModifier = if (useLegacyUi) Modifier.background(MaterialTheme.colorScheme.background) else Modifier.background(
+                    Brush.verticalGradient(
+                        listOf(Color(0xFF00D4FF), Color(0xFF8B5CF6))
+                    )
+                )
                 Scaffold(
-                    modifier = Modifier.fillMaxSize(),
-                    containerColor = MaterialTheme.colorScheme.background,
+                    modifier = Modifier.fillMaxSize().then(backgroundModifier),
+                    containerColor = Color.Transparent,
                     topBar = { navigation.TopBar() },
                     bottomBar = { navigation.FloatingBottomBar() },
                     floatingActionButton = { navigation.FloatingActionButton() }

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeRootSection.kt
@@ -2,7 +2,10 @@ package me.rhunk.snapenhance.ui.manager.pages.home
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
@@ -22,6 +25,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.vectorResource
@@ -144,17 +149,30 @@ class HomeRootSection : Routes.Route() {
         }
         val latestUpdate by rememberAsyncMutableState(defaultValue = null) { Updater.latestRelease }
         var showQuickActionsMenu by remember { mutableStateOf(false) }
+        val useLegacyUI = context.config.root.global.uiSettings.legacyUI.get()
+        val scrollState = rememberScrollState()
+        val backgroundModifier = if (useLegacyUI) Modifier else Modifier.background(
+            brush = Brush.verticalGradient(
+                colors = listOf(
+                    MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
+                    MaterialTheme.colorScheme.background
+                )
+            )
+        )
+        val logoScale by animateFloatAsState(targetValue = if (useLegacyUI) 1f else 1.1f, animationSpec = spring())
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState())
+                .then(backgroundModifier)
+                .verticalScroll(scrollState)
         ) {
             Icon(
                 imageVector = Snapenhance, contentDescription = null,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(all = 8.dp)
-                    .align(Alignment.CenterHorizontally),
+                    .align(Alignment.CenterHorizontally)
+                    .scale(logoScale),
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeSettings.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/home/HomeSettings.kt
@@ -247,28 +247,55 @@ class HomeSettings : Routes.Route() {
 
             RowTitle(title = "UI Settings")
             ShiftedRow {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(min = 55.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Text(text = "Haptic Feedback")
-                    var hapticFeedbackEnabled by remember { mutableStateOf(context.config.root.global.uiSettings.hapticFeedback.getNullable() ?: true) }
-                    val hapticFeedback = LocalHapticFeedback.current
-                    Switch(
-                        checked = hapticFeedbackEnabled,
-                        onCheckedChange = {
-                            if (it) {
-                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                            }
-                            hapticFeedbackEnabled = it
-                            context.config.root.global.uiSettings.hapticFeedback.set(it)
-                            context.config.writeConfig()
-                        },
-                        modifier = Modifier.padding(end = 26.dp)
-                    )
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 55.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(text = "Haptic Feedback")
+                        var hapticFeedbackEnabled by remember { mutableStateOf(context.config.root.global.uiSettings.hapticFeedback.getNullable() ?: true) }
+                        val hapticFeedback = LocalHapticFeedback.current
+                        Switch(
+                            checked = hapticFeedbackEnabled,
+                            onCheckedChange = {
+                                if (it) {
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                                }
+                                hapticFeedbackEnabled = it
+                                context.config.root.global.uiSettings.hapticFeedback.set(it)
+                                context.config.writeConfig()
+                            },
+                            modifier = Modifier.padding(end = 26.dp)
+                        )
+                    }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 55.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(text = "Use Legacy UI")
+                        var legacyUIEnabled by remember { mutableStateOf(context.config.root.global.uiSettings.legacyUI.getNullable() ?: false) }
+                        val hapticFeedback = LocalHapticFeedback.current
+                        Switch(
+                            checked = legacyUIEnabled,
+                            onCheckedChange = {
+                                if (context.config.root.global.uiSettings.hapticFeedback.get()) {
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                                }
+                                legacyUIEnabled = it
+                                context.config.root.global.uiSettings.legacyUI.set(it)
+                                context.config.writeConfig()
+                            },
+                            modifier = Modifier.padding(end = 26.dp)
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/overlay/RemoteOverlay.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/overlay/RemoteOverlay.kt
@@ -104,8 +104,9 @@ class RemoteOverlay(
                 setType(WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY)
             }
 
+            val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
             dialog.setContentView(
-                createComposeView(context.androidContext) {
+                createComposeView(context.androidContext, legacyUi = legacyUi) {
                     Column(
                         modifier = Modifier
                             .fillMaxSize()

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/setup/SetupActivity.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/setup/SetupActivity.kt
@@ -22,6 +22,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -85,6 +87,7 @@ class SetupActivity : ComponentActivity() {
         setContent {
             val navController = rememberNavController()
             var canGoNext by remember { mutableStateOf(false) }
+            val useLegacyUi = remember { setupContext.config.root.global.uiSettings.legacyUI.get() }
 
             fun nextScreen() {
                 if (!canGoNext) return
@@ -98,9 +101,15 @@ class SetupActivity : ComponentActivity() {
                 }
             }
 
-            AppMaterialTheme {
+            AppMaterialTheme(legacyUi = useLegacyUi) {
+                val backgroundModifier = if (useLegacyUi) Modifier.background(MaterialTheme.colorScheme.background) else Modifier.background(
+                    Brush.verticalGradient(
+                        listOf(Color(0xFF00D4FF), Color(0xFF8B5CF6))
+                    )
+                )
                 Scaffold(
-                    containerColor = MaterialTheme.colorScheme.background,
+                    modifier = Modifier.fillMaxSize().then(backgroundModifier),
+                    containerColor = Color.Transparent,
                     bottomBar = {
                         Column(
                             modifier = Modifier

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/Global.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/Global.kt
@@ -64,6 +64,7 @@ class Global : ConfigContainer() {
 
     inner class UISettings : ConfigContainer() {
         val hapticFeedback = boolean("haptic_feedback", true)
+        val legacyUI = boolean("legacy_ui")
     }
 
     val updateSettings = container("update_settings", UpdateSettings())

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/ui/ComposeViewFactory.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/ui/ComposeViewFactory.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.launch
 fun createComposeView(
     context: Context,
     viewCompositionStrategy: ViewCompositionStrategy = ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed,
+    legacyUi: Boolean = false,
     content: @Composable () -> Unit
 ) = ComposeView(context).apply {
     setViewCompositionStrategy(viewCompositionStrategy)
@@ -67,18 +68,18 @@ fun createComposeView(
     }
 
     setContent {
-        AppMaterialTheme {
+        AppMaterialTheme(legacyUi = legacyUi) {
             content()
         }
     }
 }
 
-fun createComposeAlertDialog(context: Context, builder: AlertDialog.Builder.() -> Unit = {}, content: @Composable (alertDialog: AlertDialog) -> Unit): AlertDialog {
+fun createComposeAlertDialog(context: Context, builder: AlertDialog.Builder.() -> Unit = {}, legacyUi: Boolean = false, content: @Composable (alertDialog: AlertDialog) -> Unit): AlertDialog {
     lateinit var alertDialog: AlertDialog
 
     return AlertDialog.Builder(context)
         .apply(builder)
-        .setView(createComposeView(context) {
+        .setView(createComposeView(context, legacyUi = legacyUi) {
             Surface(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/ui/Theme.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/ui/Theme.kt
@@ -2,10 +2,12 @@ package me.rhunk.snapenhance.common.ui
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 
 // ---------- Light color palette ----------
 val md_theme_light_primary = Color(0xFF6750A4)
@@ -145,12 +147,13 @@ private val DarkThemeColors = darkColorScheme(
 fun AppMaterialTheme(
     isDarkTheme: Boolean = isSystemInDarkTheme(),
     themeMode: ThemeMode? = null,
+    legacyUi: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val context = LocalContext.current
     val dynamicColor = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     val effectiveThemeMode = themeMode ?: if (isDarkTheme) ThemeMode.DARK else ThemeMode.LIGHT
-    val colorScheme = when (effectiveThemeMode) {
+    val baseScheme = when (effectiveThemeMode) {
         ThemeMode.AMOLED -> {
             val baseScheme = if (dynamicColor) dynamicDarkColorScheme(context) else DarkThemeColors
             baseScheme.copy(
@@ -169,8 +172,21 @@ fun AppMaterialTheme(
             else -> LightThemeColors
         }
     }
+    val modernScheme = baseScheme.copy(
+        primary = Color(0xFF00D4FF),
+        secondary = Color(0xFF8B5CF6),
+        tertiary = Color(0xFFFF8A00)
+    )
+    val shapes = if (legacyUi) Shapes() else Shapes(
+        extraSmall = RoundedCornerShape(8.dp),
+        small = RoundedCornerShape(12.dp),
+        medium = RoundedCornerShape(16.dp),
+        large = RoundedCornerShape(24.dp),
+        extraLarge = RoundedCornerShape(32.dp)
+    )
     MaterialTheme(
-        colorScheme = colorScheme,
+        colorScheme = if (legacyUi) baseScheme else modernScheme,
+        shapes = shapes,
         content = content
     )
 }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/SecurityFeatures.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/SecurityFeatures.kt
@@ -182,7 +182,8 @@ class SecurityFeatures(
                 visibility = ViewGroup.INVISIBLE
 
                 post {
-                    addView(createComposeView(activity) {
+                    val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+                    addView(createComposeView(activity, legacyUi = legacyUi) {
                         Surface(
                             modifier = Modifier.fillMaxSize()
                         ) {

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/action/impl/BulkMessagingAction.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/action/impl/BulkMessagingAction.kt
@@ -573,7 +573,8 @@ class BulkMessagingAction : AbstractAction() {
 
     override fun run() {
         context.coroutineScope.launch(Dispatchers.Main) {
-            createComposeAlertDialog(context.mainActivity!!) {
+            val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+            createComposeAlertDialog(context.mainActivity!!, legacyUi = legacyUi) {
                 BulkMessagingDialog()
             }.apply {
                 setCanceledOnTouchOutside(false)

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/action/impl/ExportChatMessages.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/action/impl/ExportChatMessages.kt
@@ -273,7 +273,8 @@ class ExportChatMessages : AbstractAction() {
 
     override fun run() {
         context.coroutineScope.launch(Dispatchers.Main) {
-            createComposeAlertDialog(context.mainActivity!!) { alertDialog ->
+            val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+            createComposeAlertDialog(context.mainActivity!!, legacyUi = legacyUi) { alertDialog ->
                 ExporterDialog { alertDialog }
             }.apply {
                 setCanceledOnTouchOutside(false)

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/action/impl/ExportMemories.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/action/impl/ExportMemories.kt
@@ -375,7 +375,8 @@ class ExportMemories : AbstractAction() {
                 return@launch
             }
 
-            createComposeAlertDialog(context.mainActivity!!) { alertDialog ->
+            val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+            createComposeAlertDialog(context.mainActivity!!, legacyUi = legacyUi) { alertDialog ->
                 ExporterDialog(database) { alertDialog.dismiss() }
             }.apply {
                 setOnDismissListener { database.close() }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/action/impl/ManageFriendList.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/action/impl/ManageFriendList.kt
@@ -257,7 +257,8 @@ class ManageFriendList : AbstractAction() {
 
     override fun run() {
         context.coroutineScope.launch(Dispatchers.Main) {
-            createComposeAlertDialog(context.mainActivity!!) {
+            val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+            createComposeAlertDialog(context.mainActivity!!, legacyUi = legacyUi) {
                 ManagerDialog()
             }.apply {
                 setCanceledOnTouchOutside(false)

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/experiments/AccountSwitcher.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/experiments/AccountSwitcher.kt
@@ -238,8 +238,9 @@ class AccountSwitcher: Feature("Account Switcher") {
 
     private fun showManagementPopup() {
         context.runOnUiThread {
-            createComposeAlertDialog(context.mainActivity!!) {
-                AppMaterialTheme(isDarkTheme = true) {
+            val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+            createComposeAlertDialog(context.mainActivity!!, legacyUi = legacyUi) {
+                AppMaterialTheme(isDarkTheme = true, legacyUi = legacyUi) {
                     Surface(
                         modifier = Modifier.fillMaxWidth(),
                         color = MaterialTheme.colorScheme.surface

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/experiments/AppLock.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/experiments/AppLock.kt
@@ -64,8 +64,9 @@ class AppLock : Feature("AppLock") {
         isUnlockRequested = true
         hideRootView()
 
-        val lockedView = rootContentView.findViewWithTag<View>("locked_view") ?: createComposeView(rootContentView.context) {
-            AppMaterialTheme(isDarkTheme = true) {
+        val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+        val lockedView = rootContentView.findViewWithTag<View>("locked_view") ?: createComposeView(rootContentView.context, legacyUi = legacyUi) {
+            AppMaterialTheme(isDarkTheme = true, legacyUi = legacyUi) {
                 Surface(
                     color = MaterialTheme.colorScheme.surface,
                 ) {

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/experiments/ComposerHooks.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/experiments/ComposerHooks.kt
@@ -37,7 +37,8 @@ class ComposerHooks: Feature("ComposerHooks") {
     private val getImportsFunctionName = Random.nextLong().absoluteValue.toString(16)
 
     private val composerConsole by lazy {
-        createComposeAlertDialog(context.mainActivity!!) {
+        val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+        createComposeAlertDialog(context.mainActivity!!, legacyUi = legacyUi) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/experiments/EndToEndEncryption.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/experiments/EndToEndEncryption.kt
@@ -269,7 +269,8 @@ class EndToEndEncryption : MessagingRuleFeature(
                     val publicKey = pkRequests[messageId.toLong()]
 
                     if (publicKey != null || secret != null) {
-                        viewGroup.addView(createComposeView(context.mainActivity!!) {
+                        val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+                        viewGroup.addView(createComposeView(context.mainActivity!!, legacyUi = legacyUi) {
                             Card(
                                 modifier = Modifier.fillMaxWidth().padding(8.dp),
                                 onClick = {

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/experiments/MediaFilePicker.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/experiments/MediaFilePicker.kt
@@ -199,8 +199,9 @@ class MediaFilePicker : Feature("Media File Picker") {
                                 visibility = View.VISIBLE
                                 bringToFront()
                             } != null) return
+                        val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
                         event.parent.addView(
-                            createComposeView(context.mainActivity!!) {
+                            createComposeView(context.mainActivity!!, legacyUi = legacyUi) {
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
                                     horizontalArrangement = Arrangement.End

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/messaging/SendOverride.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/messaging/SendOverride.kt
@@ -239,7 +239,8 @@ class SendOverride : Feature("Send Override") {
             }
 
             context.runOnUiThread {
-                createComposeAlertDialog(context.mainActivity!!) { alertDialog ->
+                val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+                createComposeAlertDialog(context.mainActivity!!, legacyUi = legacyUi) { alertDialog ->
                     val mainTranslation = remember {
                         context.translation.getCategory("send_override_dialog")
                     }

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/ConversationToolbox.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/ConversationToolbox.kt
@@ -110,7 +110,8 @@ class ConversationToolbox : Feature("Conversation Toolbox") {
             return
         }
 
-        createComposeAlertDialog(context.mainActivity!!) { alertDialog ->
+        val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+        createComposeAlertDialog(context.mainActivity!!, legacyUi = legacyUi) { alertDialog ->
             Column(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/FriendNotes.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/FriendNotes.kt
@@ -38,7 +38,8 @@ class FriendNotes: Feature("Friend Notes") {
 
                 viewGroup.removeView(composerRootView)
 
-                val manageNotesView = createComposeView(viewGroup.context, ViewCompositionStrategy.DisposeOnDetachedFromWindow) {
+                val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+                val manageNotesView = createComposeView(viewGroup.context, ViewCompositionStrategy.DisposeOnDetachedFromWindow, legacyUi = legacyUi) {
                     val primaryColor = remember { Color(this@FriendNotes.context.userInterface.colorPrimary) }
                     var isFetched by remember { mutableStateOf(false) }
                     var scopeNotes by rememberAsyncMutableState(null) {

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/MessageIndicators.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/features/impl/ui/MessageIndicators.kt
@@ -43,7 +43,8 @@ class MessageIndicators : Feature("Message Indicators") {
                     if (message.contentType != ContentType.SNAP.id && message.contentType != ContentType.EXTERNAL_MEDIA.id) return@chatMessage
                     val reader = ProtoReader(message.messageContent ?: return@chatMessage)
 
-                    createComposeView(event.view.context) {
+                    val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+                    createComposeView(event.view.context, legacyUi = legacyUi) {
                         Box(
                             modifier = Modifier
                                 .fillMaxWidth()

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/ui/InAppOverlay.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/ui/InAppOverlay.kt
@@ -64,8 +64,8 @@ class InAppOverlay(
             Hooker.ephemeralHook(Activity::class.java, "onPostCreate", HookStage.AFTER) { param ->
                 val contentView = param.thisObject<Activity>().findViewById<FrameLayout>(android.R.id.content)
                 contentView.children().forEach { it.visibility = View.GONE }
-                val screenView = createComposeView(param.thisObject()) {
-                    AppMaterialTheme(isDarkTheme = true) {
+                val screenView = createComposeView(param.thisObject(), legacyUi = false) {
+                    AppMaterialTheme(isDarkTheme = true, legacyUi = false) {
                         Surface(
                             color = MaterialTheme.colorScheme.surface
                         ) {
@@ -207,8 +207,9 @@ class InAppOverlay(
         val root = activity.findViewById<FrameLayout>(android.R.id.content)
         activity.runOnUiThread {
             if (root.findViewWithTag<View>(overlayTag) != null) return@runOnUiThread
-            root.addView(createComposeView(activity) {
-                AppMaterialTheme(isDarkTheme = remember { activity.isDarkTheme() }) {
+            val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+            root.addView(createComposeView(activity, legacyUi = legacyUi) {
+                AppMaterialTheme(isDarkTheme = remember { activity.isDarkTheme() }, legacyUi = legacyUi) {
                     OverlayContent()
                 }
             }.apply {

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/ui/menu/impl/FriendFeedInfoMenu.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/ui/menu/impl/FriendFeedInfoMenu.kt
@@ -157,8 +157,10 @@ class FriendFeedInfoMenu : AbstractMenu() {
         }
 
         withContext(Dispatchers.Main) {
+            val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
             createComposeAlertDialog(
                 context.mainActivity!!,
+                legacyUi = legacyUi,
             ) {
                 var pageIndex by remember { mutableIntStateOf(0) }
                 val messages = remember { mutableStateListOf<@Composable () -> Unit>() }
@@ -544,8 +546,9 @@ class FriendFeedInfoMenu : AbstractMenu() {
             }
         }
 
+        val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
         viewConsumer(
-            createComposeView(actionSheetItemsContainer.context) {
+            createComposeView(actionSheetItemsContainer.context, legacyUi = legacyUi) {
                 CompositionLocalProvider(
                     LocalTextStyle provides LocalTextStyle.current.merge(TextStyle(fontFamily = FontFamily(
                         Font(context.userInterface.avenirNextFontId, FontWeight.Medium)
@@ -575,7 +578,7 @@ class FriendFeedInfoMenu : AbstractMenu() {
                     )
 
                     orientation = LinearLayout.VERTICAL
-                    addView(createComposeView(actionSheetItemsContainer.context) {
+                    addView(createComposeView(actionSheetItemsContainer.context, legacyUi = legacyUi) {
                         Surface(
                             modifier = Modifier.fillMaxWidth(),
                             color = MaterialTheme.colorScheme.surface

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/ui/menu/impl/NewChatActionMenu.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/ui/menu/impl/NewChatActionMenu.kt
@@ -73,7 +73,8 @@ class NewChatActionMenu : AbstractMenu() {
     fun showChatEditHistory(
         edits: List<LoggedChatEdit>,
     ) {
-        createComposeAlertDialog(context.mainActivity!!) {
+        val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+        createComposeAlertDialog(context.mainActivity!!, legacyUi = legacyUi) {
             LazyColumn(
                 modifier = Modifier.padding(16.dp),
             ) {
@@ -104,7 +105,8 @@ class NewChatActionMenu : AbstractMenu() {
         val messageLogger = this@NewChatActionMenu.context.feature(MessageLogger::class)
         val messaging = this@NewChatActionMenu.context.feature(Messaging::class)
 
-        return createComposeView(context) {
+        val legacyUi = this@NewChatActionMenu.context.config.root.global.uiSettings.legacyUI.get()
+        return createComposeView(context, legacyUi = legacyUi) {
             Card(
                 modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 0.dp, bottom = 0.dp)
             ) {
@@ -226,7 +228,8 @@ class NewChatActionMenu : AbstractMenu() {
         val messageLogger = context.feature(MessageLogger::class)
         val messaging = context.feature(Messaging::class)
 
-        val composeView = createComposeView(event.view.context) {
+        val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+        val composeView = createComposeView(event.view.context, legacyUi = legacyUi) {
             val primaryColor = remember { if (event.view.context.isDarkTheme()) Color.White else Color.Black }
             val avenirNextMediumFont = remember {
                 FontFamily(

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/ui/menu/impl/OperaContextActionMenu.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/ui/menu/impl/OperaContextActionMenu.kt
@@ -136,7 +136,8 @@ class OperaContextActionMenu : AbstractMenu() {
         if (context.config.global.videoPlaybackRateSlider.get()) {
             val operaViewerParamsOverride = context.feature(OperaViewerParamsOverride::class)
 
-            linearLayout.addView(createComposeView(view.context) {
+            val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+            linearLayout.addView(createComposeView(view.context, legacyUi = legacyUi) {
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/core/src/main/kotlin/me/rhunk/snapenhance/core/ui/menu/impl/OperaViewerIcons.kt
+++ b/core/src/main/kotlin/me/rhunk/snapenhance/core/ui/menu/impl/OperaViewerIcons.kt
@@ -71,7 +71,8 @@ class OperaViewerIcons : AbstractMenu() {
                     override fun onViewDetachedFromWindow(v: View) {}
                 })
 
-                addView(createComposeView(parent.context) {
+                val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+                addView(createComposeView(parent.context, legacyUi = legacyUi) {
                     Icon(
                         imageVector = Icons.Outlined.Download,
                         tint = Color.White,
@@ -105,7 +106,8 @@ class OperaViewerIcons : AbstractMenu() {
                     ?.let { return it[0] to it[2] }
             }
 
-            parent.addView(createComposeView(parent.context)  {
+            val legacyUi = context.config.root.global.uiSettings.legacyUI.get()
+            parent.addView(createComposeView(parent.context, legacyUi = legacyUi)  {
                 Icon(
                     imageVector = Icons.Default.RemoveRedEye,
                     tint = Color.White,


### PR DESCRIPTION
## Summary
- allow switching between legacy and modern UI via Home Settings
- introduce gradient background and subtle animation on home screen

## Testing
- `./gradlew test` *(fails: insufficient memory for Java Runtime Environment)*

------
https://chatgpt.com/codex/tasks/task_e_68bd94fb30808324804cb3807f4b4ef8