### PR TITLE
style: round buttons like bottom bar

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/scripting/ScriptingRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/scripting/ScriptingRootSection.kt
@@ -442,9 +442,9 @@ class ScriptingRootSection : Routes.Route() {
         val tabTitles = listOf("Installed Scripts", "Catalog")
 
         Column(Modifier.fillMaxSize()) {
-            TabRow(selectedTabIndex = tab) {
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.padding(8.dp)) {
                 tabTitles.forEachIndexed { i, text ->
-                    Tab(
+                    SegmentedButton(
                         selected = tab == i,
                         onClick = {
                             if (i == 1 && scriptingFolder == null) {
@@ -453,7 +453,8 @@ class ScriptingRootSection : Routes.Route() {
                                 selectedTab = i
                             }
                         },
-                        text = { Text(text) }
+                        shape = SegmentedButtonDefaults.itemShape(i, tabTitles.size),
+                        label = { Text(text) }
                     )
                 }
             }

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/social/SocialRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/social/SocialRootSection.kt
@@ -32,7 +32,6 @@ import me.rhunk.snapenhance.common.util.snap.BitmojiSelfie
 import me.rhunk.snapenhance.storage.*
 import me.rhunk.snapenhance.ui.manager.Routes
 import me.rhunk.snapenhance.ui.util.coil.BitmojiImage
-import me.rhunk.snapenhance.ui.util.pagerTabIndicatorOffset
 
 class SocialRootSection : Routes.Route() {
     private var friendList: List<MessagingFriendInfo> by mutableStateOf(emptyList())
@@ -252,23 +251,17 @@ class SocialRootSection : Routes.Route() {
         }
 
         Column(modifier = Modifier.fillMaxSize()) {
-            TabRow(selectedTabIndex = pagerState.currentPage, indicator = { tabPositions ->
-                TabRowDefaults.SecondaryIndicator(
-                    Modifier.pagerTabIndicatorOffset(
-                        pagerState = pagerState,
-                        tabPositions = tabPositions
-                    )
-                )
-            }) {
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.padding(8.dp)) {
                 titles.forEachIndexed { index, title ->
-                    Tab(
+                    SegmentedButton(
                         selected = pagerState.currentPage == index,
                         onClick = {
                             coroutineScope.launch {
                                 pagerState.animateScrollToPage(index)
                             }
                         },
-                        text = {
+                        shape = SegmentedButtonDefaults.itemShape(index, titles.size),
+                        label = {
                             Text(
                                 text = title,
                                 maxLines = 2,

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/ui/Theme.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/ui/Theme.kt
@@ -2,10 +2,12 @@ package me.rhunk.snapenhance.common.ui
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 
 // ---------- Light color palette ----------
 val md_theme_light_primary = Color(0xFF6750A4)
@@ -169,8 +171,16 @@ fun AppMaterialTheme(
             else -> LightThemeColors
         }
     }
+    val shapes = Shapes(
+        extraSmall = RoundedCornerShape(24.dp),
+        small = RoundedCornerShape(24.dp),
+        medium = RoundedCornerShape(24.dp),
+        large = RoundedCornerShape(24.dp),
+        extraLarge = RoundedCornerShape(24.dp)
+    )
     MaterialTheme(
         colorScheme = colorScheme,
+        shapes = shapes,
         content = content
     )
 }


### PR DESCRIPTION
## Summary
- align all app button corner radii with the bottom floating bar
- replace social and scripts tab switchers with detached rounded segmented buttons

## Testing
- `./gradlew -Dorg.gradle.jvmargs="-Xmx2g -Xms1g" --no-daemon --console=plain :common:build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda9caae808324a0e7e5282a5cdf36