### PR TITLE
style: round buttons like bottom bar

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/MainActivity.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/MainActivity.kt
@@ -16,8 +16,12 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
-import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.navigation.NavGraph.Companion.findStartDestination
@@ -84,10 +88,30 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     containerColor = MaterialTheme.colorScheme.background,
                     topBar = { navigation.TopBar() },
-                    bottomBar = { navigation.FloatingBottomBar() },
-                    floatingActionButton = { navigation.FloatingActionButton() }
+                    floatingActionButton = { navigation.FloatingActionButton() },
+                    // Disable automatic padding so content can draw behind the bottom bar
+                    contentWindowInsets = WindowInsets(0, 0, 0, 0)
                 ) { innerPadding ->
-                    navigation.Content(innerPadding, startDestination)
+                    Box(Modifier.fillMaxSize()) {
+                        // Account for the floating bottom bar height (80.dp) and its
+                        // vertical spacing so the last items remain readable when scrolled
+                        val bottomPadding = 80.dp + 16.dp +
+                            WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+                        val contentPadding = PaddingValues(
+                            top = innerPadding.calculateTopPadding(),
+                            start = innerPadding.calculateStartPadding(LayoutDirection.Ltr),
+                            end = innerPadding.calculateEndPadding(LayoutDirection.Ltr),
+                            bottom = bottomPadding
+                        )
+                        navigation.Content(contentPadding, startDestination)
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .align(Alignment.BottomCenter)
+                        ) {
+                            navigation.FloatingBottomBar()
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/scripting/ScriptingRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/scripting/ScriptingRootSection.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
@@ -442,9 +443,18 @@ class ScriptingRootSection : Routes.Route() {
         val tabTitles = listOf("Installed Scripts", "Catalog")
 
         Column(Modifier.fillMaxSize()) {
-            TabRow(selectedTabIndex = tab) {
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp)
+            ) {
                 tabTitles.forEachIndexed { i, text ->
-                    Tab(
+                    val shape = when (i) {
+                        0 -> RoundedCornerShape(topStart = 24.dp, bottomStart = 24.dp)
+                        tabTitles.lastIndex -> RoundedCornerShape(topEnd = 24.dp, bottomEnd = 24.dp)
+                        else -> RoundedCornerShape(0.dp)
+                    }
+                    SegmentedButton(
                         selected = tab == i,
                         onClick = {
                             if (i == 1 && scriptingFolder == null) {
@@ -453,7 +463,10 @@ class ScriptingRootSection : Routes.Route() {
                                 selectedTab = i
                             }
                         },
-                        text = { Text(text) }
+                        shape = shape,
+                        modifier = Modifier.weight(1f),
+                        icon = {},
+                        label = { Text(text) }
                     )
                 }
             }

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/social/SocialRootSection.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/manager/pages/social/SocialRootSection.kt
@@ -32,7 +32,6 @@ import me.rhunk.snapenhance.common.util.snap.BitmojiSelfie
 import me.rhunk.snapenhance.storage.*
 import me.rhunk.snapenhance.ui.manager.Routes
 import me.rhunk.snapenhance.ui.util.coil.BitmojiImage
-import me.rhunk.snapenhance.ui.util.pagerTabIndicatorOffset
 
 class SocialRootSection : Routes.Route() {
     private var friendList: List<MessagingFriendInfo> by mutableStateOf(emptyList())
@@ -252,23 +251,28 @@ class SocialRootSection : Routes.Route() {
         }
 
         Column(modifier = Modifier.fillMaxSize()) {
-            TabRow(selectedTabIndex = pagerState.currentPage, indicator = { tabPositions ->
-                TabRowDefaults.SecondaryIndicator(
-                    Modifier.pagerTabIndicatorOffset(
-                        pagerState = pagerState,
-                        tabPositions = tabPositions
-                    )
-                )
-            }) {
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp)
+            ) {
                 titles.forEachIndexed { index, title ->
-                    Tab(
+                    val shape = when (index) {
+                        0 -> RoundedCornerShape(topStart = 24.dp, bottomStart = 24.dp)
+                        titles.lastIndex -> RoundedCornerShape(topEnd = 24.dp, bottomEnd = 24.dp)
+                        else -> RoundedCornerShape(0.dp)
+                    }
+                    SegmentedButton(
                         selected = pagerState.currentPage == index,
                         onClick = {
                             coroutineScope.launch {
                                 pagerState.animateScrollToPage(index)
                             }
                         },
-                        text = {
+                        shape = shape,
+                        modifier = Modifier.weight(1f),
+                        icon = {},
+                        label = {
                             Text(
                                 text = title,
                                 maxLines = 2,

--- a/app/src/main/kotlin/me/rhunk/snapenhance/ui/setup/SetupActivity.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/ui/setup/SetupActivity.kt
@@ -1,6 +1,6 @@
 package me.rhunk.snapenhance.ui.setup
 
-import android.annotation.SuppressLint
+import android.app.Activity
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
@@ -14,7 +14,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,7 +22,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.navigationBars
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -36,7 +45,6 @@ import me.rhunk.snapenhance.ui.setup.screens.impl.SaveFolderScreen
 
 
 class SetupActivity : ComponentActivity() {
-    @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -99,41 +107,30 @@ class SetupActivity : ComponentActivity() {
             }
 
             AppMaterialTheme {
-                Scaffold(
-                    containerColor = MaterialTheme.colorScheme.background,
-                    bottomBar = {
-                        Column(
-                            modifier = Modifier
-                                .fillMaxWidth(),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            val alpha: Float by animateFloatAsState(if (canGoNext) 1f else 0f,
-                                label = "NextButton"
-                            )
+                val background = MaterialTheme.colorScheme.background
+                val isLight = background.luminance() > 0.5f
+                val view = LocalView.current
+                SideEffect {
+                    val window = (view.context as Activity).window
+                    window.statusBarColor = Color.Transparent.toArgb()
+                    window.navigationBarColor = Color.Transparent.toArgb()
+                    WindowCompat.setDecorFitsSystemWindows(window, false)
+                    val insetsController = WindowInsetsControllerCompat(window, window.decorView)
+                    insetsController.isAppearanceLightStatusBars = isLight
+                    insetsController.isAppearanceLightNavigationBars = isLight
+                }
 
-                            FilledIconButton(
-                                onClick = { nextScreen() },
-                                modifier = Modifier.padding(50.dp)
-                                    .width(60.dp)
-                                    .height(60.dp)
-                                    .alpha(alpha)
-                            ) {
-                                Icon(
-                                    imageVector = if (requiredScreens.size <= 1 && canGoNext) {
-                                        Icons.Default.Check
-                                    } else {
-                                        Icons.AutoMirrored.Default.ArrowForwardIos
-                                    },
-                                    contentDescription = null
-                                )
-                            }
-                        }
-                    },
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(background)
                 ) {
+                    val bottomPadding = 110.dp +
+                        WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
                     Column(
                         modifier = Modifier
-                            .background(MaterialTheme.colorScheme.background)
                             .fillMaxSize()
+                            .padding(bottom = bottomPadding)
                     ) {
                         NavHost(
                             navController = navController,
@@ -157,6 +154,29 @@ class SetupActivity : ComponentActivity() {
                                 }
                             }
                         }
+                    }
+
+                    val alpha: Float by animateFloatAsState(if (canGoNext) 1f else 0f,
+                        label = "NextButton"
+                    )
+
+                    FilledIconButton(
+                        onClick = { nextScreen() },
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .navigationBarsPadding()
+                            .padding(bottom = 50.dp)
+                            .size(60.dp)
+                            .alpha(alpha)
+                    ) {
+                        Icon(
+                            imageVector = if (requiredScreens.size <= 1 && canGoNext) {
+                                Icons.Default.Check
+                            } else {
+                                Icons.AutoMirrored.Default.ArrowForwardIos
+                            },
+                            contentDescription = null
+                        )
                     }
                 }
             }

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/ui/Theme.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/ui/Theme.kt
@@ -2,10 +2,12 @@ package me.rhunk.snapenhance.common.ui
 
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 
 // ---------- Light color palette ----------
 val md_theme_light_primary = Color(0xFF6750A4)
@@ -169,8 +171,16 @@ fun AppMaterialTheme(
             else -> LightThemeColors
         }
     }
+    val shapes = Shapes(
+        extraSmall = RoundedCornerShape(24.dp),
+        small = RoundedCornerShape(24.dp),
+        medium = RoundedCornerShape(24.dp),
+        large = RoundedCornerShape(24.dp),
+        extraLarge = RoundedCornerShape(24.dp)
+    )
     MaterialTheme(
         colorScheme = colorScheme,
+        shapes = shapes,
         content = content
     )
 }


### PR DESCRIPTION
## Summary
- align all app button corner radii with the bottom floating bar
- replace social and scripts tab switchers with detached rounded segmented buttons
- stretch social and script tab switchers to full width with highlight only (no icons)
- match social and script tab switcher corner sizes to the bottom bar
- float bottom navigation bar with content behind and pad scroll areas for readability
- present setup flow edge-to-edge with a floating next button
- compute bottom padding using an explicit 80dp bar height

## Testing
- `./gradlew -Dorg.gradle.jvmargs="-Xmx2g -Xms1g" --no-daemon --console=plain :common:build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda9caae808324a0e7e5282a5cdf36